### PR TITLE
Fixed broken filter logic added tasksubmissioncounts

### DIFF
--- a/frontend/src/app/run/run-async-admin-view/run-async-admin-view.component.html
+++ b/frontend/src/app/run/run-async-admin-view/run-async-admin-view.component.html
@@ -40,8 +40,7 @@
           <ng-container matColumnDef="past">
             <th mat-header-cell *matHeaderCellDef>Submissions</th>
             <td mat-cell *matCellDef="let task">
-              <!-- {{ (task | enhanceTaskPastInfo: this.pastTasksValue)?.numberOfSubmissions || 'n/a' }} -->
-              {{ (task.templateId | submissionsOf: (runId | async) | async)?.length}}
+              {{ (taskSubmissionCounts | async)?.get(task.templateId) ?? 0 }}
             </td>
           </ng-container>
 
@@ -123,9 +122,9 @@
 
               <!-- Submissions Column -->
               <ng-container matColumnDef="past">
-                <th mat-header-cell *matHeaderCellDef>Submisssions</th>
+                <th mat-header-cell *matHeaderCellDef>Submissions</th>
                 <td mat-cell *matCellDef="let task">
-                  {{ (task.id | submissionsOf: (runId | async) | async)?.length}}
+                  {{ (taskSubmissionCounts | async)?.get(task.id) ?? 0 }}
                 </td>
               </ng-container>
 

--- a/frontend/src/app/run/run-async-admin-view/run-async-admin-view.component.ts
+++ b/frontend/src/app/run/run-async-admin-view/run-async-admin-view.component.ts
@@ -1,10 +1,10 @@
 import { AfterViewInit, Component, OnDestroy, ViewChild } from "@angular/core";
-import { BehaviorSubject, combineLatest, merge, Observable, of, Subject, timer } from 'rxjs';
+import { BehaviorSubject, combineLatest, forkJoin, merge, Observable, of, Subject, timer } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AppConfig } from '../../app.config';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog } from '@angular/material/dialog';
-import { catchError, filter, map, shareReplay, switchMap } from 'rxjs/operators';
+import { catchError, filter, map, shareReplay, switchMap, take } from 'rxjs/operators';
 import { RunInfoOverviewTuple } from '../admin-run-list.component';
 import { MatAccordion } from '@angular/material/expansion';
 import {
@@ -32,6 +32,7 @@ export class RunAsyncAdminViewComponent implements AfterViewInit, OnDestroy {
   displayedColumnsTasks: string[] = ['name', 'comment', 'group', 'type', 'duration', 'past'];
   displayedColumnsTeamTasks: string[] = ['name', 'comment', 'state', 'group', 'type', 'duration', 'past', 'action'];
   teams: Observable<ApiTeamInfo[]>;
+  taskSubmissionCounts: Observable<Map<string, number>>;
   pastTasks = new BehaviorSubject<ApiTaskTemplateInfo[]>([]);
   pastTasksValue: ApiTaskTemplateInfo[];
   nbOpenTeamOverviews = 0;
@@ -81,6 +82,26 @@ export class RunAsyncAdminViewComponent implements AfterViewInit, OnDestroy {
         return runAndOverview.runInfo.teams;
       }),
       shareReplay({ bufferSize: 1, refCount: true }) /* Cache last successful loading. */
+    );
+
+    this.taskSubmissionCounts = merge(timer(0, 15000), this.update).pipe(
+      switchMap(() => this.run.pipe(take(1))),
+      switchMap(run => {
+        const runId = this.runId.getValue();
+        const templates = run?.runInfo?.taskTemplates ?? [];
+        if (templates.length === 0) return of(new Map<string, number>());
+        return forkJoin(
+          templates.map(t =>
+            this.runAdminService.getApiV2EvaluationAdminByEvaluationIdSubmissionListByTemplateId(runId, t.templateId).pipe(
+              map(infos => ({ key: t.templateId, count: infos.flatMap(i => i.submissions).length })),
+              catchError(() => of({ key: t.templateId, count: 0 }))
+            )
+          )
+        ).pipe(
+          map(results => new Map(results.map(r => [r.key, r.count])))
+        );
+      }),
+      shareReplay({ bufferSize: 1, refCount: true })
     );
   }
 

--- a/frontend/src/app/services/pipes/submissions-of.pipe.ts
+++ b/frontend/src/app/services/pipes/submissions-of.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from "@angular/core";
 import { ApiSubmission, EvaluationAdministratorService } from "../../../../openapi";
-import { flatMap, Observable } from "rxjs";
-import { filter, tap } from "rxjs/operators";
+import { Observable } from "rxjs";
+import { map } from "rxjs/operators";
 
 @Pipe({
     name: "submissionsOf",
@@ -21,21 +21,7 @@ export class SubmissionsOfPipe implements PipeTransform {
     return this.adminService
       .getApiV2EvaluationAdminByEvaluationIdSubmissionListByTemplateId(evaluationId, templateId)
       .pipe(
-        tap(e => {
-          console.log("submissionsOf 1", e);
-        }),
-        filter((submissionInfos, idx) => {
-          return submissionInfos[idx]?.evaluationId === evaluationId || false;
-        }),
-        tap(e => {
-          console.log("submissionsOf 2", e);
-        }),
-        flatMap(submissionInfos => {
-          return submissionInfos.filter(it => it.evaluationId === evaluationId).map(it => it.submissions);
-        }),
-        tap(e => {
-          console.log("submissionsOf 3", e);
-        })
+        map(submissionInfos => submissionInfos.flatMap(info => info.submissions))
       );
   }
 


### PR DESCRIPTION
1. submissions-of.pipe.ts — Fixed the broken filter logic. The old filter used
 submissionInfos[idx] (stream index as array index) to check evaluationId, which always filtered out the result when the array was empty.
 Replaced the whole filter+flatMap chain with a simple map(infos => infos.flatMap(i =>
 i.submissions)).
 2. run-async-admin-view.component.ts — Added taskSubmissionCounts: Observable<Map<string, number>>. It's driven by merge(timer(0, 15000), this.update) so it refreshes every 15 seconds and immediately whenever the refresh/start/terminate action fires. It fetches all template counts in parallel via forkJoin, builds a Map<templateId, count>, and shares the result.
 3. run-async-admin-view.component.html — Both submission count cells now use
 (taskSubmissionCounts |
 async)?.get(task.templateId) (Tasks Overview) and (taskSubmissionCounts | async)?.get(task.id) (Tasks per Team), replacing the stale pure-pipe calls. Also fixed the typo "Submisssions" → "Submissions".